### PR TITLE
feat: add indicator to completion

### DIFF
--- a/models/venture.lua
+++ b/models/venture.lua
@@ -2,22 +2,39 @@ local Venture = {
     level_range = '',
     area = '',
     completion = 0,
-    location = ''
+    location = '',
+    last_update_time = 0,
+    last_increment_time = 0
 };
 
 -- Create new venture instance
 function Venture:new(data)
     local instance = setmetatable({}, { __index = Venture });
-    instance:update(data);
+    local now = os.time();
+    instance.level_range = data.level_range;
+    instance.area = data.area;
+    instance.completion = tonumber(data.completion) or 0;
+    instance.location = data.loc;
+    instance.last_update_time = now;
+    instance.last_increment_time = 0; -- Start as red
     return instance;
 end
 
 -- Update venture data
 function Venture:update(data)
+    local now = os.time();
+    local new_completion = tonumber(data.completion) or 0;
+    if new_completion > self.completion then
+        self.last_increment_time = now;
+    elseif new_completion < self.completion then
+        -- Reset detected, set to red
+        self.last_increment_time = 0;
+    end
     self.level_range = data.level_range;
     self.area = data.area;
-    self.completion = tonumber(data.completion) or 0;
+    self.completion = new_completion;
     self.location = data.loc;
+    self.last_update_time = now;
 end
 
 -- Get completion percentage


### PR DESCRIPTION
The color of the indicator is based on time since the last change in the completion.

The indicator is green if the last change was less than 7 minutes ago, yellow if it was between 7 and 15 minutes ago, and red if it was more than 15 minutes ago.

The indicator is shown in the completion column.

The indicator also has different characters for different completion types:
- green: "^"
- yellow: "="
- red: "x"