### PR TITLE
Added option for location notes as tooltip

### DIFF
--- a/configs/config.lua
+++ b/configs/config.lua
@@ -14,6 +14,7 @@ local default_settings = T{
     stopped_indicator = '.';
     fast_indicator = '^';
     slow_indicator = '-';
+    notes_visible = false;
 };
 
 local settings = require('settings');

--- a/services/config_ui.lua
+++ b/services/config_ui.lua
@@ -43,6 +43,12 @@ function config_ui:draw()
             config.set('enable_alerts', alerts[1]);
         end
 
+        -- Notes Tooltip Visible Toggle
+        local notes_visible = { config.get('notes_visible') }
+        if imgui.Checkbox('Show Notes as Tooltip', notes_visible) then
+            config.set('notes_visible', notes_visible[1])
+        end
+
         imgui.Separator();  -- visual divider between sections
 
         -- Play Audio
@@ -98,6 +104,8 @@ function config_ui:draw()
             config.set('slow_indicator', slow[1])
         end
         imgui.PopItemWidth()
+
+
     end
     imgui.End();
     config.set('show_config_gui', open[1])

--- a/services/parser.lua
+++ b/services/parser.lua
@@ -78,7 +78,7 @@ function parser:parse_exp_areas(lines)
                 equipment = vnm_equipment or "",
                 element = vnm_element or "",
                 crest = vnm_crest or "",
-                notes = vnm_notes and string.format("(%s)", vnm_notes) or ""
+                notes = vnm_notes and string.format("%s", vnm_notes) or ""
             };
             local v = existing[level_range]
             if v then

--- a/ui/rows.lua
+++ b/ui/rows.lua
@@ -87,11 +87,14 @@ function rows:draw_venture_row(venture)
 
     -- Location and Notes
     local location = venture:get_location()
-    local notes = venture:get_notes()
-    if notes and notes ~= "" then
-        imgui.Text(location .. " - " .. notes)
-    else
-        imgui.Text(location)
+    imgui.Text(location);
+    if imgui.IsItemHovered() then
+        local notes = venture:get_notes()
+        if notes and notes ~= "" then
+            imgui.BeginTooltip()
+            imgui.Text(notes)
+            imgui.EndTooltip()
+        end
     end
     imgui.NextColumn();
 end

--- a/ui/rows.lua
+++ b/ui/rows.lua
@@ -87,13 +87,22 @@ function rows:draw_venture_row(venture)
 
     -- Location and Notes
     local location = venture:get_location()
-    imgui.Text(location);
-    if imgui.IsItemHovered() then
-        local notes = venture:get_notes()
+    local notes = venture.get_notes and venture:get_notes() or nil
+    local notes_visible = config.get('notes_visible')
+    if notes_visible then
+        imgui.Text(location)
+        if imgui.IsItemHovered() then
+            if notes and notes ~= "" then
+                imgui.BeginTooltip()
+                imgui.Text(notes)
+                imgui.EndTooltip()
+            end
+        end
+    else
         if notes and notes ~= "" then
-            imgui.BeginTooltip()
-            imgui.Text(notes)
-            imgui.EndTooltip()
+            imgui.Text(location .. " - " .. notes)
+        else
+            imgui.Text(location)
         end
     end
     imgui.NextColumn();


### PR DESCRIPTION
Also added it to the settings so the user can either have them always displayed or packed into a tooltip.  Tweaked the parser to remove the (around the notes)

![image](https://github.com/user-attachments/assets/c23c8e21-07a0-43ca-a3ff-c8328dc6634c)

or

![image](https://github.com/user-attachments/assets/1b47d1ae-33fe-48ec-aa8a-3ff1f1f27207)
looks a little off but when you see the pointer it looks normal.